### PR TITLE
3 3.1.4 select method of payment for buy

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -153,6 +153,7 @@ import { ButtonWarnDirective } from './models/theme/button/button-warn.directive
 import { MapComponent } from './components/map/map.component';
 import { RadioComponent } from './components/custom-form/input/radio/radio.component';
 import { MapSearchComponent } from './components/map/map-search/map-search.component';
+import { RadioLabelDirective } from './components/custom-form/input/radio/label/radio-label.directive';
 
 
 @NgModule({
@@ -244,7 +245,8 @@ import { MapSearchComponent } from './components/map/map-search/map-search.compo
     ButtonEmptyDirective,
     RadioComponent,
     ButtonWarnDirective,
-    MapSearchComponent
+    MapSearchComponent,
+    RadioLabelDirective
   ],
   imports: [
     BrowserModule,

--- a/frontend/src/app/components/checkout/stagable/buy-item/buy-item.component.ts
+++ b/frontend/src/app/components/checkout/stagable/buy-item/buy-item.component.ts
@@ -22,14 +22,15 @@ export class BuyItemComponent extends StagableExtention {
     productService: ProductService,
     userService: UserService
   ) {
-    super(componentFactoryResolver, [{
-      title: 'Shipping',
-      component: ShippingComponent,
-      componentRef: null
-    },
+    super(componentFactoryResolver, [
     {
       title: 'Payment Method',
       component: PaymentMethodComponent,
+      componentRef: null
+    },
+    {
+      title: 'Shipping',
+      component: ShippingComponent,
       componentRef: null
     }],
     route,

--- a/frontend/src/app/components/checkout/stagable/buy-item/buy-item.component.ts
+++ b/frontend/src/app/components/checkout/stagable/buy-item/buy-item.component.ts
@@ -23,18 +23,23 @@ export class BuyItemComponent extends StagableExtention {
     userService: UserService
   ) {
     super(componentFactoryResolver, [
-    {
-      title: 'Payment Method',
-      component: PaymentMethodComponent,
-      componentRef: null
-    },
-    {
-      title: 'Shipping',
-      component: ShippingComponent,
-      componentRef: null
-    }],
+      {
+        title: 'Shipping',
+        component: ShippingComponent,
+        componentRef: null
+      },
+      {
+        title: 'Payment Method',
+        component: PaymentMethodComponent,
+        componentRef: null
+      }
+    ],
     route,
     productService,
     userService);
+  }
+
+  protected finalize: (stageIndex: number, data?: any) => void = (stageIndex: number): void => {
+    console.log(this.dataStorage);
   }
 }

--- a/frontend/src/app/components/checkout/stagable/stagable-extention.ts
+++ b/frontend/src/app/components/checkout/stagable/stagable-extention.ts
@@ -14,7 +14,7 @@ import { UserModel, NullUser } from '../../../models/user/user.model';
 @Directive({
   selector: '[stagable]'
 })
-export class StagableExtention extends Stagable implements OnInit {
+export abstract class StagableExtention extends Stagable implements OnInit {
 
   public product: ProductModel = new NullProduct();
   public seller: CutUserModel = new NullCutUser();

--- a/frontend/src/app/components/checkout/stagable/stage/payment-method/payment-method.component.html
+++ b/frontend/src/app/components/checkout/stagable/stage/payment-method/payment-method.component.html
@@ -1,4 +1,10 @@
 <stage>
+  <div class="stage-content" content theme>
+    <radio-selection placeholder="Payment Method" [options]="[['Wallet', 'wallet'], ['PayPal', 'paypal']]">
+      <img *radioLabel="1" class="paypal-logo" src="https://www.paypalobjects.com/webstatic/de_DE/i/de-pp-logo-200px.png" alt="PayPal Logo"/>
+    </radio-selection>
+  </div>
+
   <button navigation type="button" name="button" (click)="previousStage()" theme buttonEmpty [disabled]="isFirstStage">Previous</button>
   <button navigation type="button" name="button" (click)="finalizeStages()" theme button>Finish</button>
 </stage>

--- a/frontend/src/app/components/checkout/stagable/stage/payment-method/payment-method.component.html
+++ b/frontend/src/app/components/checkout/stagable/stage/payment-method/payment-method.component.html
@@ -1,10 +1,10 @@
 <stage>
   <div class="stage-content" content theme>
-    <radio-selection placeholder="Select Payment Method" [options]="[['Wallet', 'wallet'], ['PayPal', 'paypal']]">
+    <radio-selection placeholder="Select Payment Method" [options]="options" [(ngModel)]="paymentMethod">
       <img theme *radioLabel="1" class="paypal-logo" src="https://www.paypalobjects.com/webstatic/de_DE/i/de-pp-logo-200px.png" alt="PayPal Logo"/>
     </radio-selection>
   </div>
 
   <button navigation type="button" name="button" (click)="previousStage()" theme buttonEmpty [disabled]="isFirstStage">Previous</button>
-  <button navigation type="button" name="button" (click)="finalizeStages()" theme button>Finish</button>
+  <button navigation type="button" name="button" (click)="finalizeStages()" theme button [disabled]="paymentMethod ? false : true">Finish</button>
 </stage>

--- a/frontend/src/app/components/checkout/stagable/stage/payment-method/payment-method.component.html
+++ b/frontend/src/app/components/checkout/stagable/stage/payment-method/payment-method.component.html
@@ -1,7 +1,7 @@
 <stage>
   <div class="stage-content" content theme>
-    <radio-selection placeholder="Payment Method" [options]="[['Wallet', 'wallet'], ['PayPal', 'paypal']]">
-      <img *radioLabel="1" class="paypal-logo" src="https://www.paypalobjects.com/webstatic/de_DE/i/de-pp-logo-200px.png" alt="PayPal Logo"/>
+    <radio-selection placeholder="Select Payment Method" [options]="[['Wallet', 'wallet'], ['PayPal', 'paypal']]">
+      <img theme *radioLabel="1" class="paypal-logo" src="https://www.paypalobjects.com/webstatic/de_DE/i/de-pp-logo-200px.png" alt="PayPal Logo"/>
     </radio-selection>
   </div>
 

--- a/frontend/src/app/components/checkout/stagable/stage/payment-method/payment-method.component.scss
+++ b/frontend/src/app/components/checkout/stagable/stage/payment-method/payment-method.component.scss
@@ -5,7 +5,7 @@
   padding: $spaceing-xs;
   height: 100%;
   border-radius: $border-radius;
-  background: $dark-bright;
+  background: white;
 }
 
 @each $theme-name in $theme-names {

--- a/frontend/src/app/components/checkout/stagable/stage/payment-method/payment-method.component.scss
+++ b/frontend/src/app/components/checkout/stagable/stage/payment-method/payment-method.component.scss
@@ -1,0 +1,13 @@
+@import '../../../../../../variables.scss';
+@import './payment-method.component.theme.scss';
+
+.paypal-logo {
+  padding: $spaceing-xs;
+  height: 100%;
+  border-radius: $border-radius;
+  background: $dark-bright;
+}
+
+@each $theme-name in $theme-names {
+  @include payment-method-theme($theme-name);
+}

--- a/frontend/src/app/components/checkout/stagable/stage/payment-method/payment-method.component.theme.scss
+++ b/frontend/src/app/components/checkout/stagable/stage/payment-method/payment-method.component.theme.scss
@@ -1,0 +1,3 @@
+@mixin payment-method-theme($theme-name) {
+
+}

--- a/frontend/src/app/components/checkout/stagable/stage/payment-method/payment-method.component.ts
+++ b/frontend/src/app/components/checkout/stagable/stage/payment-method/payment-method.component.ts
@@ -7,5 +7,18 @@ import { StageNDEExtention } from '../stage-navigation-data-emitter-extention.di
   styleUrls: ['./payment-method.component.scss']
 })
 export class PaymentMethodComponent extends StageNDEExtention<string> {
-  public getData():string {return ''};
+  public options: Array<[string, string]> = [
+    ['Wallet', 'wallet'],
+    ['PayPal', 'paypal']
+  ]
+  public paymentMethod: string;
+
+  public getData(): string {
+    return this.paymentMethod;
+  };
+
+  public finalizeStages(): void {
+    this.emitData();
+    super.finalizeStages();
+  }
 }

--- a/frontend/src/app/components/custom-form/input/radio/label/radio-label.directive.spec.ts
+++ b/frontend/src/app/components/custom-form/input/radio/label/radio-label.directive.spec.ts
@@ -1,0 +1,8 @@
+import { RadioLabelDirective } from './radio-label.directive';
+
+describe('RadioLabelDirective', () => {
+  it('should create an instance', () => {
+    const directive = new RadioLabelDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/frontend/src/app/components/custom-form/input/radio/label/radio-label.directive.ts
+++ b/frontend/src/app/components/custom-form/input/radio/label/radio-label.directive.ts
@@ -1,0 +1,27 @@
+import { Directive, Input, TemplateRef } from '@angular/core';
+
+@Directive({
+  selector: '[radioLabel]'
+})
+export class RadioLabelDirective {
+
+  private _optionId: number;
+
+  @Input()
+  set radioLabel(optionId: number) {
+    this._optionId = optionId;
+  }
+
+  constructor(
+    private _template: TemplateRef<any>
+  ) { }
+
+  get optionId(): number {
+    return this._optionId;
+  }
+
+  get template(): TemplateRef<any> {
+    return this._template;
+  }
+
+}

--- a/frontend/src/app/components/custom-form/input/radio/radio.component.html
+++ b/frontend/src/app/components/custom-form/input/radio/radio.component.html
@@ -2,11 +2,14 @@
   <label>
     {{placeholder}}
   </label>
-  <div *ngFor="let option of optionsWithTemplate">
-    <label>
+  <div class="radio" theme *ngFor="let option of optionsWithTemplate">
+    <label class="checkbox">
       {{option[0]}}
+      <div class="checkmark-wrapper" >
+        <input [type]="type" (blur)="touch()" (focus)="focus()" (change)="onSelect(option[1])" [name]="placeholder" [checked]="option[1] === value ? 'checked' : ''">
+        <div class="checkmark"></div>
+      </div>
     </label>
     <ng-container [ngTemplateOutlet]="option[2]"></ng-container>
-    <input [type]="type" (blur)="touch()" (focus)="focus()" (change)="onSelect(option[1])" [name]="placeholder" [checked]="option[1] === value ? 'checked' : ''">
   </div>
 </div>

--- a/frontend/src/app/components/custom-form/input/radio/radio.component.html
+++ b/frontend/src/app/components/custom-form/input/radio/radio.component.html
@@ -2,14 +2,16 @@
   <label>
     {{placeholder}}
   </label>
-  <div class="radio" theme *ngFor="let option of optionsWithTemplate">
-    <label class="checkbox">
-      {{option[0]}}
-      <div class="checkmark-wrapper" >
-        <input [type]="type" (blur)="touch()" (focus)="focus()" (change)="onSelect(option[1])" [name]="placeholder" [checked]="option[1] === value ? 'checked' : ''">
-        <div class="checkmark"></div>
-      </div>
-    </label>
-    <ng-container [ngTemplateOutlet]="option[2]"></ng-container>
+  <div class="radio-wrapper">
+    <div class="radio" theme *ngFor="let option of optionsWithTemplate">
+      <label class="checkbox">
+        {{option[0]}}
+        <div class="checkmark-wrapper" >
+          <input [type]="type" (blur)="touch()" (focus)="focus()" (change)="onSelect(option[1])" [name]="placeholder" [checked]="option[1] === value ? 'checked' : ''">
+          <div class="checkmark"></div>
+        </div>
+      </label>
+      <ng-container [ngTemplateOutlet]="option[2]"></ng-container>
+    </div>
   </div>
 </div>

--- a/frontend/src/app/components/custom-form/input/radio/radio.component.html
+++ b/frontend/src/app/components/custom-form/input/radio/radio.component.html
@@ -2,10 +2,11 @@
   <label>
     {{placeholder}}
   </label>
-  <div *ngFor="let option of options">
+  <div *ngFor="let option of optionsWithTemplate">
     <label>
       {{option[0]}}
     </label>
+    <ng-container [ngTemplateOutlet]="option[2]"></ng-container>
     <input [type]="type" (blur)="touch()" (focus)="focus()" (change)="onSelect(option[1])" [name]="placeholder" [checked]="option[1] === value ? 'checked' : ''">
   </div>
 </div>

--- a/frontend/src/app/components/custom-form/input/radio/radio.component.scss
+++ b/frontend/src/app/components/custom-form/input/radio/radio.component.scss
@@ -1,86 +1,96 @@
 @import '../../../../../variables.scss';
 @import './radio.component.theme.scss';
 
-.radio {
-  display: flex;
-  align-items: center;
-  .checkbox {
-    position: relative;
-    display: flex;
-    align-items: center;
-    font-size: 1em;
-    line-height: 1em;
-    border-radius: $border-radius;
-    padding: $spaceing-xs;
-    margin-right: $spaceing-m;
-    margin-left: $spaceing-m;
+.radio-wrapper {
+  display: grid;
+  grid-template-columns: max-content;
+  grid-template-rows: repeat(2, 2*$spaceing-m);
+  grid-gap: $spaceing-xs;
 
-    $dot-dimensions: $spaceing-xs/2;
+  .radio {
+    display: grid;
+    grid-template-columns: max-content max-content;
+    grid-gap: $spaceing-xs;
 
-    &::before {
-      content: "";
-      height: $dot-dimensions;
-      width: $dot-dimensions;
-      border-radius: 50%;
-      position: absolute;
-      left: -$dot-dimensions/2 - $spaceing-m/2;
-    }
-
-    .checkmark-wrapper {
-
-      $checkmark-dimensions: $spaceing-m;
-
-      cursor: pointer;
-      -webkit-user-select: none;
-      -moz-user-select: none;
-      -ms-user-select: none;
-      user-select: none;
+    .checkbox {
       position: relative;
-      height: $checkmark-dimensions;
-      width: $checkmark-dimensions;
       display: flex;
       align-items: center;
-      margin-left: $spaceing-s;
+      font-size: 1em;
+      line-height: 1em;
+      border-radius: $border-radius;
+      padding: $spaceing-xs;
+      margin: 0 0 0 $spaceing-m;
 
+      $dot-dimensions: $spaceing-xs/2;
 
-      input {
+      &::before {
+        content: "";
+        height: $dot-dimensions;
+        width: $dot-dimensions;
+        border-radius: 50%;
         position: absolute;
-        opacity: 0;
-        cursor: pointer;
-        height: 0;
-        width: 0;
+        left: -$dot-dimensions/2 - $spaceing-m/2;
+      }
 
-        &:checked {
-          ~ {
-            .checkmark {
-              &::after {
-                display: block;
+      .checkmark-wrapper {
+
+        $checkmark-dimensions: $spaceing-m;
+
+        cursor: pointer;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+        position: relative;
+        height: $checkmark-dimensions;
+        width: $checkmark-dimensions;
+        display: flex;
+        align-items: center;
+        margin-left: $spaceing-s;
+
+
+        input {
+          position: absolute;
+          opacity: 0;
+          cursor: pointer;
+          height: 0;
+          width: 0;
+
+          &:checked {
+            ~ {
+              .checkmark {
+                &::after {
+                  display: block;
+                }
               }
             }
           }
+
         }
 
-      }
-
-      .checkmark {
-        height: 100%;
-        width: 100%;
-        border-radius: 50%;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-
-        &::after {
-          content: "";
-          display: none;
-          height: 50%;
-          width: 50%;
+        .checkmark {
+          height: 100%;
+          width: 100%;
           border-radius: 50%;
+          display: flex;
+          justify-content: center;
+          align-items: center;
+
+          &::after {
+            content: "";
+            display: none;
+            height: 50%;
+            width: 50%;
+            border-radius: 50%;
+          }
         }
       }
     }
   }
 }
+
+
 
 @each $theme-name in $theme-names {
   @include radio-theme($theme-name);

--- a/frontend/src/app/components/custom-form/input/radio/radio.component.scss
+++ b/frontend/src/app/components/custom-form/input/radio/radio.component.scss
@@ -1,0 +1,87 @@
+@import '../../../../../variables.scss';
+@import './radio.component.theme.scss';
+
+.radio {
+  display: flex;
+  align-items: center;
+  .checkbox {
+    position: relative;
+    display: flex;
+    align-items: center;
+    font-size: 1em;
+    line-height: 1em;
+    border-radius: $border-radius;
+    padding: $spaceing-xs;
+    margin-right: $spaceing-m;
+    margin-left: $spaceing-m;
+
+    $dot-dimensions: $spaceing-xs/2;
+
+    &::before {
+      content: "";
+      height: $dot-dimensions;
+      width: $dot-dimensions;
+      border-radius: 50%;
+      position: absolute;
+      left: -$dot-dimensions/2 - $spaceing-m/2;
+    }
+
+    .checkmark-wrapper {
+
+      $checkmark-dimensions: $spaceing-m;
+
+      cursor: pointer;
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+      position: relative;
+      height: $checkmark-dimensions;
+      width: $checkmark-dimensions;
+      display: flex;
+      align-items: center;
+      margin-left: $spaceing-s;
+
+
+      input {
+        position: absolute;
+        opacity: 0;
+        cursor: pointer;
+        height: 0;
+        width: 0;
+
+        &:checked {
+          ~ {
+            .checkmark {
+              &::after {
+                display: block;
+              }
+            }
+          }
+        }
+
+      }
+
+      .checkmark {
+        height: 100%;
+        width: 100%;
+        border-radius: 50%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+
+        &::after {
+          content: "";
+          display: none;
+          height: 50%;
+          width: 50%;
+          border-radius: 50%;
+        }
+      }
+    }
+  }
+}
+
+@each $theme-name in $theme-names {
+  @include radio-theme($theme-name);
+}

--- a/frontend/src/app/components/custom-form/input/radio/radio.component.theme.scss
+++ b/frontend/src/app/components/custom-form/input/radio/radio.component.theme.scss
@@ -1,0 +1,50 @@
+@mixin radio-theme($theme-name) {
+
+  $theme: map-get($themes, $theme-name);
+
+  $checkbox-bg: get-theme($theme-name, dark);
+  $dot-bg: get-theme($theme-name, bright);
+  $checkmark-unchecked: map-get($theme, highlight);
+  $checkmark-checked: map-get($theme, accent);
+  $checkmark-color: map-get($theme, bright);
+  $checkmark-hover: map-get($theme, light);
+
+
+  .radio.#{$theme-name} {
+    .checkbox {
+      background: $checkbox-bg;
+
+      &::before {
+        background: $dot-bg;
+      }
+
+      .checkmark-wrapper {
+        input {
+          &:checked {
+            ~ {
+              .checkmark {
+                background-color: $checkmark-checked;
+              }
+            }
+          }
+        }
+
+        &:hover {
+          > {
+            .checkmark {
+              background-color: $checkmark-hover;
+            }
+          }
+        }
+
+        .checkmark {
+          background-color: $checkmark-unchecked;
+
+          &::after {
+            background-color: $checkmark-color;
+          }
+        }
+      }
+    }
+  }
+}

--- a/frontend/src/app/components/custom-form/input/radio/radio.component.ts
+++ b/frontend/src/app/components/custom-form/input/radio/radio.component.ts
@@ -12,27 +12,27 @@ import { RadioLabelDirective } from '../../../custom-form/input/radio/label/radi
     {provide: NG_VALUE_ACCESSOR, useExisting: RadioComponent, multi: true}
   ]
 })
-export class RadioComponent extends ValueAccessorBase<any> {
+export class RadioComponent<T> extends ValueAccessorBase<T> {
   public type: string = "radio";
 
   @Input()
   public placeholder: string;
 
   @Input()
-  set options(options: Array<[string, any]>) {
+  set options(options: Array<[string, T]>) {
     this.value = options[0][1];
     this._options = options;
   }
-  get options(): Array<[string, any]> {
+  get options(): Array<[string, T]> {
     return this._options;
   }
-  private _options: Array<[string, any]> = new Array<[string, any]>();
+  private _options: Array<[string, T]> = new Array<[string, T]>();
 
-  public optionsWithTemplate: Array<[string, any, TemplateRef<any>]> = new Array<[string, any, TemplateRef<any>]>();
+  public optionsWithTemplate: Array<[string, T, TemplateRef<any>]> = new Array<[string, T, TemplateRef<any>]>();
 
   @ContentChildren(RadioLabelDirective)
   set labels(labels: QueryList<RadioLabelDirective>) {
-    this.optionsWithTemplate = this.options.map((option: [string, any], optionId: number) => {
+    this.optionsWithTemplate = this.options.map((option: [string, T], optionId: number) => {
       const labelTemplate: TemplateRef<any> = this.getTemplateById(labels, optionId);
 
       return [option[0], option[1], labelTemplate];
@@ -56,11 +56,11 @@ export class RadioComponent extends ValueAccessorBase<any> {
     super(themeService);
   }
 
-  public onSelect(option: string) {
+  public onSelect(option: T) {
     this.value = option;
   }
 
-  public writeValue(value: string) {
+  public writeValue(value: T) {
     super.writeValue(value);
     if (value) {
       this.dirty = true;

--- a/frontend/src/app/components/custom-form/input/radio/radio.component.ts
+++ b/frontend/src/app/components/custom-form/input/radio/radio.component.ts
@@ -19,7 +19,14 @@ export class RadioComponent extends ValueAccessorBase<any> {
   public placeholder: string;
 
   @Input()
-  public options: Array<[string, any]> = new Array<[string, any]>();
+  set options(options: Array<[string, any]>) {
+    this.value = options[0][1];
+    this._options = options;
+  }
+  get options(): Array<[string, any]> {
+    return this._options;
+  }
+  private _options: Array<[string, any]> = new Array<[string, any]>();
 
   public optionsWithTemplate: Array<[string, any, TemplateRef<any>]> = new Array<[string, any, TemplateRef<any>]>();
 

--- a/frontend/src/app/components/custom-form/input/radio/radio.component.ts
+++ b/frontend/src/app/components/custom-form/input/radio/radio.component.ts
@@ -1,10 +1,11 @@
-import { Component, Input, Optional, Inject, ViewChild } from '@angular/core';
+import { Component, Input, ContentChildren, QueryList, TemplateRef } from '@angular/core';
 import { NgModel, NG_VALUE_ACCESSOR, NG_VALIDATORS, NG_ASYNC_VALIDATORS } from '@angular/forms';
 import { ValueAccessorBase } from '../../value-accessor-base';
 import { ThemeService } from '../../../../services/theme/theme.service';
+import { RadioLabelDirective } from '../../../custom-form/input/radio/label/radio-label.directive';
 
 @Component({
-  selector: 'app-radio',
+  selector: 'radio-selection',
   templateUrl: './radio.component.html',
   styleUrls: ['./radio.component.scss'],
   providers: [
@@ -19,6 +20,28 @@ export class RadioComponent extends ValueAccessorBase<any> {
 
   @Input()
   public options: Array<[string, any]> = new Array<[string, any]>();
+
+  public optionsWithTemplate: Array<[string, any, TemplateRef<any>]> = new Array<[string, any, TemplateRef<any>]>();
+
+  @ContentChildren(RadioLabelDirective)
+  set labels(labels: QueryList<RadioLabelDirective>) {
+    this.optionsWithTemplate = this.options.map((option: [string, any], optionId: number) => {
+      const labelTemplate: TemplateRef<any> = this.getTemplateById(labels, optionId);
+
+      return [option[0], option[1], labelTemplate];
+    });
+  }
+
+  private getTemplateById(labels: QueryList<RadioLabelDirective>, optionId: number): TemplateRef<any> {
+    let labelTemplate: TemplateRef<any>;
+    labels.toArray().every((label: RadioLabelDirective) => {
+      if (label.optionId == optionId) {
+        labelTemplate = label.template;
+        return false;
+      } else return true;
+    });
+    return labelTemplate;
+  }
 
   constructor(
     themeService: ThemeService


### PR DESCRIPTION
### Payment Method
The payment method can be selected now on the second stage of the `BuyItemComponent` (`Stagable`). The selection allows for 'Wallet' and 'PayPal'. The implementation for PayPal is going to take place later in the project. 

For the purpose of creating this selection I created a radio button selection (custom-form) which has a `ValueAccessorBase`.  
There is also a basic implementation for the data handling in the `BuyItemComponent` on finalizing the stages.